### PR TITLE
add role support and last ditch search top level directory

### DIFF
--- a/lib/jamie/vagrant.rb
+++ b/lib/jamie/vagrant.rb
@@ -47,6 +47,7 @@ module Jamie
           chef.run_list = instance.run_list
           chef.json = instance.attributes
           chef.data_bags_path = instance.suite.data_bags_path
+          chef.roles_path = instance.suite.roles_path
         end
       end
     end


### PR DESCRIPTION
I didn't know a better way to do this. I am using Jamie to dev on a knife solo repo and wanted integration tests on my "web" role that used rbenv, nginx, passenger, etc.

The only way I could think to get around this was to make a plugin that called super then did the roles stuff, however the driver needs to implement it as well.

If you can think of a better way to implement this, I'm happy to do it another way. I know you want to keep core small.
