### PR TITLE
Logging Support

### DIFF
--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -1284,24 +1284,26 @@ module Jamie
     end
 
     def upload_cookbooks(scp)
-      cookbooks_dir = local_cookbooks
-      scp.upload!(cookbooks_dir, "#{chef_home}/cookbooks",
+      ckbks_dir = local_cookbooks
+      scp.upload!(ckbks_dir, "#{chef_home}/cookbooks",
         :recursive => true
       ) do |ch, name, sent, total|
-        file = name.sub(%r{^#{cookbooks_dir}/}, '')
-        info("#{file}: #{sent}/#{total}")
+        if sent == total
+          info("Uploaded #{name.sub(%r{^#{ckbks_dir}/}, '')} (#{total} bytes)")
+        end
       end
     ensure
-      FileUtils.rmtree(cookbooks_dir)
+      FileUtils.rmtree(ckbks_dir)
     end
 
     def upload_data_bags(scp)
-      data_bags_dir = instance.suite.data_bags_path
-      scp.upload!(data_bags_dir, "#{chef_home}/data_bags",
+      dbags_dir = instance.suite.data_bags_path
+      scp.upload!(dbags_dir, "#{chef_home}/data_bags",
         :recursive => true
       ) do |ch, name, sent, total|
-        file = name.sub(%r{^#{data_bags_dir}/}, '')
-        info("#{file}: #{sent}/#{total}")
+        if sent == total
+          info("Uploaded #{name.sub(%r{^#{dbags_dir}/}, '')} (#{total} bytes)")
+        end
       end
     end
 
@@ -1310,8 +1312,9 @@ module Jamie
       scp.upload!(roles_dir, "#{chef_home}/roles",
         :recursive => true
       ) do |ch, name, sent, total|
-        file = name.sub(%r{^#{roles_dir}/}, '')
-        info("#{file}: #{sent}/#{total}")
+        if sent == total
+          info("Uploaded #{name.sub(%r{^#{roles_dir}/}, '')} (#{total} bytes)")
+        end
       end
     end
 

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -679,35 +679,35 @@ module Jamie
 
     def create_action
       banner "Creating instance #{name}"
-      action(:create) { |state| driver.create(self, state) }
+      action(:create) { |state| driver.create(state) }
       info "Creation of instance #{name} complete."
       self
     end
 
     def converge_action
       banner "Converging instance #{name}"
-      action(:converge) { |state| driver.converge(self, state) }
+      action(:converge) { |state| driver.converge(state) }
       info "Convergence of instance #{name} complete."
       self
     end
 
     def setup_action
       banner "Setting up instance #{name}"
-      action(:setup) { |state| driver.setup(self, state) }
+      action(:setup) { |state| driver.setup(state) }
       info "Setup of instance #{name} complete."
       self
     end
 
     def verify_action
       banner "Verifying instance #{name}"
-      action(:verify) { |state| driver.verify(self, state) }
+      action(:verify) { |state| driver.verify(state) }
       info "Verification of instance #{name} complete."
       self
     end
 
     def destroy_action
       banner "Destroying instance #{name}"
-      action(:destroy) { |state| driver.destroy(self, state) }
+      action(:destroy) { |state| driver.destroy(state) }
       destroy_state
       info "Destruction of instance #{name} complete."
       self
@@ -1033,38 +1033,33 @@ module Jamie
 
       # Creates an instance.
       #
-      # @param instance [Instance] an instance
       # @param state [Hash] mutable instance and driver state
       # @raise [ActionFailed] if the action could not be completed
-      def create(instance, state) ; end
+      def create(state) ; end
 
       # Converges a running instance.
       #
-      # @param instance [Instance] an instance
       # @param state [Hash] mutable instance and driver state
       # @raise [ActionFailed] if the action could not be completed
-      def converge(instance, state) ; end
+      def converge(state) ; end
 
       # Sets up an instance.
       #
-      # @param instance [Instance] an instance
       # @param state [Hash] mutable instance and driver state
       # @raise [ActionFailed] if the action could not be completed
-      def setup(instance, state) ; end
+      def setup(state) ; end
 
       # Verifies a converged instance.
       #
-      # @param instance [Instance] an instance
       # @param state [Hash] mutable instance and driver state
       # @raise [ActionFailed] if the action could not be completed
-      def verify(instance, state) ; end
+      def verify(state) ; end
 
       # Destroys an instance.
       #
-      # @param instance [Instance] an instance
       # @param state [Hash] mutable instance and driver state
       # @raise [ActionFailed] if the action could not be completed
-      def destroy(instance, state) ; end
+      def destroy(state) ; end
 
       protected
 
@@ -1100,26 +1095,26 @@ module Jamie
 
     # Base class for a driver that uses SSH to communication with an instance.
     # A subclass must implement the following methods:
-    # * #create(instance, state)
-    # * #destroy(instance, state)
+    # * #create(state)
+    # * #destroy(state)
     #
     # @author Fletcher Nichol <fnichol@nichol.ca>
     class SSHBase < Base
 
-      def create(instance, state)
+      def create(state)
         raise NotImplementedError, "#create must be implemented by subclass."
       end
 
-      def converge(instance, state)
+      def converge(state)
         ssh_args = build_ssh_args(state)
 
         install_omnibus(ssh_args) if config['require_chef_omnibus']
         prepare_chef_home(ssh_args)
-        upload_chef_data(ssh_args, instance)
+        upload_chef_data(ssh_args)
         run_chef_solo(ssh_args)
       end
 
-      def setup(instance, state)
+      def setup(state)
         ssh_args = build_ssh_args(state)
 
         if instance.jr.setup_cmd
@@ -1127,7 +1122,7 @@ module Jamie
         end
       end
 
-      def verify(instance, state)
+      def verify(state)
         ssh_args = build_ssh_args(state)
 
         if instance.jr.run_cmd
@@ -1136,7 +1131,7 @@ module Jamie
         end
       end
 
-      def destroy(instance, state)
+      def destroy(state)
         raise NotImplementedError, "#destroy must be implemented by subclass."
       end
 
@@ -1166,7 +1161,7 @@ module Jamie
         ssh(ssh_args, "sudo rm -rf #{chef_home} && mkdir -p #{chef_home}/cache")
       end
 
-      def upload_chef_data(ssh_args, instance)
+      def upload_chef_data(ssh_args)
         Jamie::ChefDataUploader.new(
           instance, ssh_args, config['jamie_root'], chef_home
         ).upload

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -1151,6 +1151,8 @@ module Jamie
 
       def build_ssh_args(state)
         opts = Hash.new
+        opts[:user_known_hosts_file] = "/dev/null"
+        opts[:paranoid] = false
         opts[:password] = config['password'] if config['password']
         opts[:keys] = Array(config['ssh_key']) if config['ssh_key']
 

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -285,6 +285,10 @@ module Jamie
 
   module Logging
 
+    def debug(progname = nil, &block)
+      add(Logger::DEBUG, nil, progname, &block)
+    end
+
     def info(progname = nil, &block)
       add(Logger::INFO, nil, progname, &block)
     end

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -54,6 +54,7 @@ module Jamie
     def default_logger
       logger = Logger.new(STDOUT)
       logger.progname = "Jamie"
+      logger.level = Util.to_logger_level(DEFAULT_LOG_LEVEL)
       logger
     end
   end
@@ -203,9 +204,12 @@ module Jamie
     end
 
     def new_instance_logger(log_root)
+      level = Util.to_logger_level(self.log_level)
+
       lambda do |name|
         logfile = File.join(log_root, "#{name}.log")
         logger = Logger.new(logfile)
+        logger.level = level
         logger.progname = name
         logger
       end
@@ -832,6 +836,10 @@ module Jamie
         gsub(/([A-Z+])([A-Z][a-z])/, '\1_\2').
         gsub(/([a-z\d])([A-Z])/, '\1_\2').
         downcase
+    end
+
+    def self.to_logger_level(symbol)
+      Logger.const_get(symbol.to_s.upcase)
     end
   end
 

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -360,7 +360,6 @@ module Jamie
 
       def banner(msg = nil, &block)
         super_info("-----> #{msg}", &block)
-        info(msg, &block)
       end
     end
 

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -37,6 +37,9 @@ require 'jamie/version'
 
 module Jamie
 
+  # Default log level verbosity
+  DEFAULT_LOG_LEVEL = :info
+
   class << self
 
     attr_accessor :logger
@@ -69,9 +72,6 @@ module Jamie
 
     # Default path to the Jamie YAML file
     DEFAULT_YAML_FILE = File.join(Dir.pwd, '.jamie.yml').freeze
-
-    # Default log level verbosity
-    DEFAULT_LOG_LEVEL = :info
 
     # Default driver plugin to use
     DEFAULT_DRIVER_PLUGIN = "dummy".freeze
@@ -115,7 +115,7 @@ module Jamie
 
     # @return [Symbol] log level verbosity
     def log_level
-      @log_level ||= DEFAULT_LOG_LEVEL
+      @log_level ||= Jamie::DEFAULT_LOG_LEVEL
     end
 
     # @return [String] base path that may contain a common `data_bags/`

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -345,7 +345,7 @@ module Jamie
 
     def logdev(filepath_or_logdev)
       if filepath_or_logdev.is_a? String
-        file = File.open(File.expand_path(filepath_or_logdev), "wb")
+        file = File.open(File.expand_path(filepath_or_logdev), "ab")
         file.sync = true
         file
       else

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -1208,11 +1208,11 @@ module Jamie
           channel.exec(cmd) do |ch, success|
 
             channel.on_data do |ch, data|
-              logger << data #.gsub(%r{^[ >-]{6} }, '')
+              logger << data
             end
 
             channel.on_extended_data do |ch, type, data|
-              logger << data #.gsub(%r{^[ >-]{6} }, '')
+              logger << data
             end
 
             channel.on_request("exit-status") do |ch, data|

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -894,7 +894,7 @@ module Jamie
 
       include ShellOut
 
-      attr_accessor :instance
+      attr_writer :instance
 
       def initialize(config)
         @config = config
@@ -948,7 +948,7 @@ module Jamie
 
       protected
 
-      attr_reader :config
+      attr_reader :config, :instance
 
       def run_command(cmd, use_sudo = nil, log_subject = nil)
         use_sudo = config['use_sudo'] if use_sudo.nil?

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -396,28 +396,10 @@ module Jamie
 
   module Logging
 
-    def banner(*args)
-      logger.banner(*args)
-    end
-
-    def debug(*args)
-      logger.debug(*args)
-    end
-
-    def info(*args)
-      logger.info(*args)
-    end
-
-    def warn(*args)
-      logger.warn(*args)
-    end
-
-    def error(*args)
-      logger.error(*args)
-    end
-
-    def fatal(*args)
-      logger.fatal(*args)
+    %w{banner debug info warn error fatal}.map(&:to_sym).each do |meth|
+      define_method(meth) do |*args|
+        logger.public_send(meth, *args)
+      end
     end
   end
 

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -862,10 +862,10 @@ module Jamie
       cmd = "sudo #{cmd}" if use_sudo
       subject = "       [#{log_subject} command]"
 
-      $stdout.puts "#{subject} (#{display_cmd(cmd)})"
+      info("#{subject} (#{display_cmd(cmd)})")
       sh = Mixlib::ShellOut.new(cmd, :live_stream => $stdout, :timeout => 60000)
       sh.run_command
-      puts "#{subject} ran in #{sh.execution_time} seconds."
+      info("#{subject} ran in #{sh.execution_time} seconds.")
       sh.error!
     rescue Mixlib::ShellOut::ShellCommandFailed => ex
       raise ShellCommandFailed, ex.message
@@ -905,6 +905,7 @@ module Jamie
     class Base
 
       include ShellOut
+      include Logging
 
       attr_writer :instance
 
@@ -961,6 +962,18 @@ module Jamie
       protected
 
       attr_reader :config, :instance
+
+      def logger
+        instance.logger
+      end
+
+      def puts(msg)
+        info(msg)
+      end
+
+      def print(msg)
+        info(msg)
+      end
 
       def run_command(cmd, use_sudo = nil, log_subject = nil)
         use_sudo = config['use_sudo'] if use_sudo.nil?

--- a/lib/jamie.rb
+++ b/lib/jamie.rb
@@ -948,6 +948,16 @@ module Jamie
 
       Logger.const_get(symbol.to_s.upcase)
     end
+
+    def self.from_logger_level(const)
+      case const
+      when Logger::DEBUG then :debug
+      when Logger::INFO then :info
+      when Logger::WARN then :warn
+      when Logger::ERROR then :error
+      else :fatal
+      end
+    end
   end
 
   # Mixin that wraps a command shell out invocation, providing a #run_command
@@ -1169,7 +1179,8 @@ module Jamie
 
       def run_chef_solo(ssh_args)
         ssh(ssh_args, <<-RUN_SOLO)
-          sudo chef-solo -c #{chef_home}/solo.rb -j #{chef_home}/dna.json
+          sudo chef-solo -c #{chef_home}/solo.rb -j #{chef_home}/dna.json \
+            --log_level #{Util.from_logger_level(logger.level)}
         RUN_SOLO
       end
 
@@ -1313,7 +1324,6 @@ module Jamie
       if instance.suite.data_bags_path
         solo << %{data_bag_path "#{chef_home}/data_bags"}
       end
-      solo << %{log_level :info}
       solo.join("\n")
     end
 

--- a/lib/jamie/driver/dummy.rb
+++ b/lib/jamie/driver/dummy.rb
@@ -29,31 +29,31 @@ module Jamie
 
       default_config 'sleep', 0
 
-      def create(instance, state)
+      def create(state)
         state['my_id'] = "#{instance.name}-#{Time.now.to_i}"
-        report(:create, instance, state)
+        report(:create, state)
       end
 
-      def converge(instance, state)
-        report(:converge, instance, state)
+      def converge(state)
+        report(:converge, state)
       end
 
-      def setup(instance, state)
-        report(:setup, instance, state)
+      def setup(state)
+        report(:setup, state)
       end
 
-      def verify(instance, state)
-        report(:verify, instance, state)
+      def verify(state)
+        report(:verify, state)
       end
 
-      def destroy(instance, state)
-        report(:destroy, instance, state)
+      def destroy(state)
+        report(:destroy, state)
         state.delete('my_id')
       end
 
       private
 
-      def report(action, instance, state)
+      def report(action, state)
         info("[Dummy] Action ##{action} called on " +
           "instance=#{instance} with state=#{state}")
         sleep(config['sleep'].to_f) if config['sleep'].to_f > 0.0

--- a/lib/jamie/driver/dummy.rb
+++ b/lib/jamie/driver/dummy.rb
@@ -54,12 +54,10 @@ module Jamie
       private
 
       def report(action, instance, state)
-        puts "[Dummy] Action ##{action} called on " +
-          "instance=#{instance} with state=#{state}"
-        if config['sleep'].to_f > 0.0
-          sleep config['sleep'].to_f
-          puts "[Dummy] Action ##{action} completed (#{config['sleep']}s)."
-        end
+        info("[Dummy] Action ##{action} called on " +
+          "instance=#{instance} with state=#{state}")
+        sleep(config['sleep'].to_f) if config['sleep'].to_f > 0.0
+        debug("[Dummy] Action ##{action} completed (#{config['sleep']}s).")
       end
     end
   end


### PR DESCRIPTION
This is a major feature and focus of Jamie, namely having per-instance log files and the ability to change log levels throughout the system, including remotely running instances.

Another goal for Jamie is concurrent execution of instances which makes good logging vital. It is no longer enough to assume that all logging will be dumped to `STDOUT` in execution order.

The current strategy is to pull in [Logger](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/logger/rdoc/Logger.html) from _stdlib_ until it is outgrown or a feature in [Logging](https://rubygems.org/gems/logging) becomes too compelling.
