### PR TITLE
Addresses more of #12

### DIFF
--- a/features/cli_init.feature
+++ b/features/cli_init.feature
@@ -3,6 +3,19 @@ Feature: Ensure that the Command Line Interface init creates the correct files
   As an Operator
   I want to initialize a cookbook
 
+Background:
+  Given a file named "metadata.rb" with:
+  """
+  name  "ntp"
+  license "Apache 2.0"
+  description "Installs and configures ntp as a client or server"
+  version "0.1.0"
+  recipe "ntp", "Installs and configures ntp either as a server or client"
+  %w{ ubuntu debian redhat centos fedora scientific amazon oracle freebsd }.each do |os|
+    supports os
+  end
+  """
+
 
 @ok
 Scenario: Basic init with no extras succeeds
@@ -47,7 +60,8 @@ Scenario: Basic init with no extras succeeds
     - recipe[yum::epel]
   suites:
   - name: default
-    run_list: []
+    run_list:
+    - recipe[ntp]
     attributes: {}
   """
   And a file named "Gemfile" should not exist
@@ -132,28 +146,10 @@ Scenario: Running the init command succeeds
 
 
 @ok
-Scenario: Running init with a correct metadata.rb works
-  Given a file named "metadata.rb" with:
-  """
-  name              "ntp"
-  license           "Apache 2.0"
-  description       "Installs and configures ntp as a client or server"
-  version           "0.1.0"
-  recipe "ntp", "Installs and configures ntp either as a server or client"
-
-  %w{ ubuntu debian redhat centos fedora scientific amazon oracle freebsd }.each do |os|
-    supports os
-  end
-  """
+Scenario: Running init with an empty metadata.rb should fail/read the folder's name
+  Given an empty file named "metadata.rb"
   When I run `jamie init` interactively
   And I type "n"
-  Then the exit status should be 0
-  And the file ".jamie.yml" should contain:
-  """
-  suites:
-  - name: default
-    run_list:
-    - recipe[ntp]
-    attributes: {}
-  """
+  Then the exit status should be 1
+  And the output should contain "Could not determine the cookbook name"
 

--- a/features/cli_init.feature
+++ b/features/cli_init.feature
@@ -114,8 +114,8 @@ Scenario: Running the init command without a Gemfile provides warning and fails
   When I run `jamie init` interactively
   And I type "y"
   And I type "jamie-vagrant"
-  And the output should contain "You do not have an existing Gemfile"
   Then the exit status should be 1
+  And the output should contain "You do not have an existing Gemfile"
 
 
 @ok

--- a/lib/jamie/cli.rb
+++ b/lib/jamie/cli.rb
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
+# Author:: Mike Fiedler (<miketheman@gmail.com>)
 #
 # Copyright (C) 2012, Fletcher Nichol
 #
@@ -300,6 +301,11 @@ module Jamie
         MetadataChopper.extract('metadata.rb').first
       else
         nil
+      end
+      if cookbook_name.nil?
+        warn %{Could not determine the cookbook name from metadata.rb}
+        warn %{Exiting...}
+        exit 1
       end
       run_list = cookbook_name ? "recipe[#{cookbook_name}]" : nil
 


### PR DESCRIPTION
This should address, to begin with, the scenario of init being run against an empty/non-existent/no 'name' in metadata.rb.

I recognize that it violates both Cane and Tailor tests - but I don't know offhand how to make the method simpler. Happy to take guidance and advice.

Ref: Jamie::InitGenerator#default_yaml
